### PR TITLE
adjusting packages in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,15 @@ LABEL "maintainer"="Mike Schneider <mschneider@se-dev.com>"
 LABEL "repo"="https://github.com/makton-dev/awscli-terraform"
 LABEL "homepage"="https://github.com/makton-dev/awscli-terraform"
 
+# Installed dependent packages
+RUN apt-get update && apt-get -y install unzip wget curl
+
 # Add terraform repo
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 
 # Install Terraform. Also unzip and wget for awscli
-RUN apt-get update && sudo apt-get install terraform unzip wget
+RUN apt-get update && apt-get -y install terraform
 
 # download and install awscli
 RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip


### PR DESCRIPTION
curl is not on the ubuntu 20.04 docker image. now apt is run more times